### PR TITLE
Pin the android.support versions and ensure the DropInUI url schema i…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,6 +28,8 @@
 
         <source-file src="src/android/BraintreePlugin.java" target-dir="src/net/justincredible" />
 
+        <framework src="com.android.support:support-v13:26.0.0" />
+        <framework src="com.android.support:appcompat-v7:26.0.0" />
         <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
 
         <config-file target="AndroidManifest.xml" parent="application">
@@ -64,6 +66,19 @@
             <string>com.paypal.ppclient.touch.v2</string>
             <string>com.venmo.touch.v2</string>
           </array>
+        </config-file>
+
+        <config-file target="*-Info.plist" parent="CFBundleURLTypes">
+            <array>
+                <dict>
+                <key>CFBundleTypeRole</key>
+                <string>Editor</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>${PRODUCT_BUNDLE_IDENTIFIER}.payments</string>
+                </array>
+                </dict>
+            </array>
         </config-file>
 
         <config-file target="*-Info.plist" parent="NSCameraUsageDescription">

--- a/scripts/add_embedded_ios_frameworks.js
+++ b/scripts/add_embedded_ios_frameworks.js
@@ -15,9 +15,9 @@ module.exports = function(context) {
     // cordova@7 embeds the frameworks so this script is not required
     if(parseInt(context.opts.cordova.version) >= 7) { return; }
 
-    function fromDir(startPath,filter, rec, multiple){
-        if (!fs.existsSync(startPath)){
-            console.log("no dir ", startPath);
+    function fromDir(startPath, filter, rec, multiple){
+        if (!fs.existsSync(startPath)) {
+            console.log("[cordova-plugin-braintree]==>no dir ", startPath);
             return;
         }
 

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -8,8 +8,8 @@ android {
 }
 
 dependencies {
-    compile 'com.braintreepayments.api:braintree:2.6.2'
-    compile 'com.braintreepayments.api:drop-in:3.1.0'
+    compile 'com.braintreepayments.api:drop-in:3.+'
+    compile 'com.google.android.gms:play-services-wallet:+'
     compile 'io.card:android-sdk:5.5.1'
 }
 


### PR DESCRIPTION
…s registered for iOS.

FYI this is not sufficient. You will need a pre-build cordova hook for android to ensure that the same android.support version is used across all your plugins, because if they conflict, the plugin will crash.